### PR TITLE
fix(docs) wrong name for resource iot_device

### DIFF
--- a/docs/resources/iot_device.md
+++ b/docs/resources/iot_device.md
@@ -1,11 +1,11 @@
 ---
 layout: "scaleway"
-page_title: "Scaleway: scaleway_iot_hub_device"
+page_title: "Scaleway: scaleway_iot_device"
 description: |-
   Manages Scaleway IoT Hub device.
 ---
 
-# scaleway_iot_hub_device
+# scaleway_iot_device
 
 -> **Note:** This terraform resource is currently in beta and might include breaking change in future releases.
 
@@ -21,7 +21,7 @@ resource scaleway_iot_hub main {
     product_plan = "plan_shared"
 }
 
-resource scaleway_iot_hub_device main {
+resource scaleway_iot_device main {
     hub_id = scaleway_iot_hub.main.id
     name   = "test-iot"
 }

--- a/docs/resources/lb.md
+++ b/docs/resources/lb.md
@@ -7,7 +7,7 @@ description: |-
 # scaleway_lb
 
 Creates and manages Scaleway Load-Balancers.
-For more information, see [the documentation](https://developers.scaleway.com/en/products/lb/api).
+For more information, see [the documentation](https://developers.scaleway.com/en/products/lb/zoned_api).
 
 ## Examples
 

--- a/docs/resources/lb_backend.md
+++ b/docs/resources/lb_backend.md
@@ -7,7 +7,7 @@ description: |-
 # scaleway_lb_backend
 
 Creates and manages Scaleway Load-Balancer Backends.
-For more information, see [the documentation](https://developers.scaleway.com/en/products/lb/api).
+For more information, see [the documentation](https://developers.scaleway.com/en/products/lb/zoned_api).
 
 ## Examples
 

--- a/docs/resources/lb_certificate.md
+++ b/docs/resources/lb_certificate.md
@@ -7,7 +7,7 @@ description: |-
 # scaleway_lb_certificate
 
 Creates and manages Scaleway Load-Balancer Certificates.
-For more information, see [the documentation](https://developers.scaleway.com/en/products/lb/api).
+For more information, see [the documentation](https://developers.scaleway.com/en/products/lb/zoned_api).
 
 ## Examples
 

--- a/docs/resources/lb_frontend.md
+++ b/docs/resources/lb_frontend.md
@@ -6,7 +6,7 @@ description: |-
 
 # scaleway_lb_frontend
 
-Creates and manages Scaleway Load-Balancer Frontends. For more information, see [the documentation](https://developers.scaleway.com/en/products/lb/api).
+Creates and manages Scaleway Load-Balancer Frontends. For more information, see [the documentation](https://developers.scaleway.com/en/products/lb/zoned_api).
 
 ## Examples
 

--- a/docs/resources/lb_ip.md
+++ b/docs/resources/lb_ip.md
@@ -7,7 +7,7 @@ description: |-
 # scaleway_lb_ip
 
 Creates and manages Scaleway Load-Balancers IPs.
-For more information, see [the documentation](https://developers.scaleway.com/en/products/lb/api).
+For more information, see [the documentation](https://developers.scaleway.com/en/products/lb/zoned_api).
 
 ## Examples
 


### PR DESCRIPTION
Replace "scaleway_iot_hub_device" with "scaleway_iot_device"